### PR TITLE
fix: keyboard works with periphery on parallel port

### DIFF
--- a/Oric-DFLAT/cia/cia.s
+++ b/Oric-DFLAT/cia/cia.s
@@ -32,7 +32,7 @@
 	code
 
 mod_sz_cia_s
-	
+
 
 ;****************************************
 ;* init_via0
@@ -55,10 +55,10 @@ init_via0_loop
 	sta IO_0,x
 	iny
 	bne init_via0_loop
-	
-init_via0_done	
+
+init_via0_done
 	rts							; return from sub
-	
+
 init_via0_tab
 	db IER, 	0x7f
 	db DDRA,	0xff			; Port A output by default
@@ -80,7 +80,7 @@ init_tape_tab
 	db ACR,		0xc0			; T1 continuous and toggle PB7
 	db T1CL,	lo(TAPE_RATE*2)	; Tape rate /2 = 0
 	db T1CH,	hi(TAPE_RATE*2)	; Tape rate /2 = 0
-	db PRB,		0x50			; Tape motor ON
+	db PRB,		0xf0			; Tape motor ON
 	db -1
 ;init_ser_tab
 ;	db IER,		0x7f			; Disable all interrupts
@@ -88,5 +88,5 @@ init_tape_tab
 ;	db PCR,		0xdd			; Ensure AY is not selected (CB1 active)
 ;	db DDRB,	0xff			; Set port B output
 ;	db -1
-	
+
 mod_sz_cia_e


### PR DESCRIPTION
This PR fixes keyboard scan routine to be compatible on HW level with standard Oric ROM and periphery connected to the parallel port. Some changes need to be done in  [kb_stick](https://github.com/6502Nerd/dflat/blob/4937b078ad5dd7f4a8dcae167599aa704eee6152/Oric-DFLAT/keyboard/keyboard.s#L46).
[Here](https://github.com/iss000/oricOpenLibrary/blob/main/lib-ijk-egoist/src/ijk-driver.s) is good code for IJK joystick interface.
Else, thanks for update. Great work ;)
